### PR TITLE
Make sure email's subject and body are UTF-8

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/notification/email/EmailSender.java
+++ b/src/main/java/org/killbill/billing/plugin/notification/email/EmailSender.java
@@ -123,6 +123,7 @@ public class EmailSender {
                 subject,
                 body));
         final SimpleEmail email = new SimpleEmail();
+        email.setCharset("utf-8");
         email.setMsg(body);
         sendEmail(to, cc, subject, email, precheckSmtp(smtp));
     }

--- a/src/main/java/org/killbill/billing/plugin/notification/generator/ResourceBundleFactory.java
+++ b/src/main/java/org/killbill/billing/plugin/notification/generator/ResourceBundleFactory.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.List;
 import java.util.Locale;
@@ -80,7 +81,7 @@ public class ResourceBundleFactory {
         final String bundle = getTenantBundleForType(locale, type, tenantContext);
         if (bundle != null) {
             try {
-                return new PropertyResourceBundle(new ByteArrayInputStream(bundle.getBytes(Charsets.UTF_8)));
+                return new PropertyResourceBundle(new InputStreamReader(new ByteArrayInputStream(bundle.getBytes(Charsets.UTF_8)), "UTF-8"));
             } catch (IOException e) {
                 logService.log(LogService.LOG_WARNING, String.format("Failed to de-serialize the property bundle for tenant %s and locale %s", tenantContext.getTenantId(), locale));
                 // Fall through...


### PR DESCRIPTION
There are 2 different issues solved in this commit:
- SimpleEmail does not set UTF-8 charset for email's body and
  uses US-ASCII by default which breaks email's content.
  Explicitly setting "utf-8" charset fixes the issue.
- PropertyResourceBundle by default uses Properties#load(InputStream)
  that uses ISO-8859-1 for reading, that makes passed UTF-8 encoded
  tenant's bundle to be encoded to ISO-8859-1 again which produces
  broken email's subject.
  See this fantastic SO answer for details of the problem
  and proposed fix: https://stackoverflow.com/a/4660195/273444