### PR TITLE
Do not hardcode merchant name in email subject

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/notification/generator/TemplateRenderer.java
+++ b/src/main/java/org/killbill/billing/plugin/notification/generator/TemplateRenderer.java
@@ -127,7 +127,7 @@ public class TemplateRenderer {
         }
 
         final String body = templateEngine.executeTemplateText(templateText, data);
-        final String subject = new StringBuffer((String) text.get("merchantName")).append(": ").append(text.get(templateType.getSubjectKeyName())).toString();
+        final String subject = text.get(templateType.getSubjectKeyName());
         return new EmailContent(subject, body);
     }
 

--- a/src/test/java/org/killbill/billing/plugin/notification/generator/TestTemplateRenderer.java
+++ b/src/test/java/org/killbill/billing/plugin/notification/generator/TestTemplateRenderer.java
@@ -144,7 +144,7 @@ public class TestTemplateRenderer {
                 "If you have any questions about your account, please reply to this email or contact MERCHANT_NAME Support at: (888) 555-1234";
 
         //System.err.println(email.getBody());
-        Assert.assertEquals(email.getSubject(), "MERCHANT_NAME: Payment Confirmation");
+        Assert.assertEquals(email.getSubject(), "Payment Confirmation");
         Assert.assertEquals(email.getBody(), expectedBody);
     }
 
@@ -183,7 +183,7 @@ public class TestTemplateRenderer {
                 "If you have any questions about your account, please reply to this email or contact MERCHANT_NAME Support at: (888) 555-1234";
 
         //System.err.println(email.getBody());
-        Assert.assertEquals(email.getSubject(), "MERCHANT_NAME: Payment Confirmation");
+        Assert.assertEquals(email.getSubject(), "Payment Confirmation");
         Assert.assertEquals(email.getBody(), expectedBody);
     }
 
@@ -228,7 +228,7 @@ public class TestTemplateRenderer {
                 "If you have any questions about your account, please reply to this email or contact MERCHANT_NAME Support at: (888) 555-1234";
 
         //System.err.println(email.getBody());
-        Assert.assertEquals(email.getSubject(), "MERCHANT_NAME: Failed Payment");
+        Assert.assertEquals(email.getSubject(), "Failed Payment");
         Assert.assertEquals(email.getBody(), expectedBody);
     }
 
@@ -249,7 +249,7 @@ public class TestTemplateRenderer {
                 "If you have any questions about your account, please reply to this email or contact MERCHANT_NAME Support at: (888) 555-1234";
 
         // System.err.println(email.getBody());
-        Assert.assertEquals(email.getSubject(), "MERCHANT_NAME: Refund Receipt");
+        Assert.assertEquals(email.getSubject(), "Refund Receipt");
         Assert.assertEquals(email.getBody(), expectedBody);
     }
 
@@ -278,7 +278,7 @@ public class TestTemplateRenderer {
                 "If you have any questions about your account, please reply to this email or contact MERCHANT_NAME Support at: (888) 555-1234";
 
         //System.err.println(email.getBody());
-        Assert.assertEquals(email.getSubject(), "MERCHANT_NAME: Subscription Canceled");
+        Assert.assertEquals(email.getSubject(), "Subscription Canceled");
         Assert.assertEquals(email.getBody(), expectedBody);
     }
 
@@ -299,7 +299,7 @@ public class TestTemplateRenderer {
                 "If you have any questions about your account, please reply to this email or contact MERCHANT_NAME Support at: (888) 555-1234";
 
         //System.err.println(email.getBody());
-        Assert.assertEquals(email.getSubject(), "MERCHANT_NAME: Subscription Ended");
+        Assert.assertEquals(email.getSubject(), "Subscription Ended");
         Assert.assertEquals(email.getBody(), expectedBody);
     }
 
@@ -335,7 +335,7 @@ public class TestTemplateRenderer {
                 "If you have any questions about your account, please reply to this email or contact MERCHANT_NAME Support at: (888) 555-1234";
 
         //System.err.println(email.getBody());
-        Assert.assertEquals(email.getSubject(), "MERCHANT_NAME: You Have a New Invoice");
+        Assert.assertEquals(email.getSubject(), "You Have a New Invoice");
 
         Assert.assertEquals(email.getBody(), expectedBody);
     }


### PR DESCRIPTION
It's quite inconvenient that merchant's name is hardcoded in email's
subject especially given the flexibility of per-tenant email templates.

It's quite easy to substitute it yourself during the configuration of
the plugin, but you have to remove the hardcoded value first.