### PR TITLE
Ignore Eclipse metadata.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,9 @@ buildNumber.properties
 *.db
 logs/
 .logs
+
+# Eclipse metadata
+.classpath
+.project
+.settings/
+


### PR DESCRIPTION
This PR adds git ignores for Eclipse metadata, so the Eclipse IDE can be used more easily with this project.