### PR TITLE
Allow InvoiceFormatter implementation to be customized

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,5 @@ logs/
 .project
 .settings/
 
+# TestNG from IDE
+/test-output

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-g# killbill-email-notifications-plugin
+# killbill-email-notifications-plugin
 
 Release builds are available on [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.kill-bill.billing.plugin.java%22%20AND%20a%3A%22killbill-email-notifications-plugin%22) with coordinates `org.kill-bill.billing.plugin.java:killbill-email-notifications-plugin`.
 

--- a/pom.xml
+++ b/pom.xml
@@ -273,7 +273,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-Activator>org.killbill.billing.plugin.notification.setup.EmailNotificationActivator</Bundle-Activator>
-                        <Export-Package />
+                        <Export-Package>org.killbill.billing.plugin.notification.api</Export-Package>
                         <Private-Package>org.killbill.billing.plugin.notification.*</Private-Package>
                         <!-- Optional resolution because exported by the Felix system bundle -->
                         <Import-Package>

--- a/pom.xml
+++ b/pom.xml
@@ -273,7 +273,10 @@
                 <configuration>
                     <instructions>
                         <Bundle-Activator>org.killbill.billing.plugin.notification.setup.EmailNotificationActivator</Bundle-Activator>
-                        <Export-Package>org.killbill.billing.plugin.notification.api</Export-Package>
+                        <Export-Package>
+                        	org.killbill.billing.plugin.notification.api,
+                        	org.killbill.billing.plugin.notification.generator.*
+                        </Export-Package>
                         <Private-Package>org.killbill.billing.plugin.notification.*</Private-Package>
                         <!-- Optional resolution because exported by the Felix system bundle -->
                         <Import-Package>

--- a/src/main/java/org/killbill/billing/plugin/notification/api/InvoiceFormatterFactory.java
+++ b/src/main/java/org/killbill/billing/plugin/notification/api/InvoiceFormatterFactory.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.killbill.billing.invoice.api.Invoice;
 import org.killbill.billing.invoice.api.formatters.InvoiceFormatter;
+import org.killbill.billing.util.callcontext.TenantContext;
 
 /**
  * API for a factory service that creates {@link InvoiceFormatter} instances.
@@ -35,11 +36,13 @@ public interface InvoiceFormatterFactory {
      * @param translator the available translations
      * @param invoice the invoice
      * @param locale the desired locale
+     * @param context the tenant context
      * @return the formatter instance, never {@literal null}
      */
     InvoiceFormatter createInvoiceFormatter(
             Map<String, String> translator,
             Invoice invoice,
-            Locale locale);
+            Locale locale,
+            TenantContext context);
 
 }

--- a/src/main/java/org/killbill/billing/plugin/notification/api/InvoiceFormatterFactory.java
+++ b/src/main/java/org/killbill/billing/plugin/notification/api/InvoiceFormatterFactory.java
@@ -25,8 +25,6 @@ import org.killbill.billing.util.callcontext.TenantContext;
 
 /**
  * API for a factory service that creates {@link InvoiceFormatter} instances.
- * 
- * @author matt
  */
 public interface InvoiceFormatterFactory {
 

--- a/src/main/java/org/killbill/billing/plugin/notification/api/InvoiceFormatterFactory.java
+++ b/src/main/java/org/killbill/billing/plugin/notification/api/InvoiceFormatterFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.plugin.notification.api;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.killbill.billing.invoice.api.Invoice;
+import org.killbill.billing.invoice.api.formatters.InvoiceFormatter;
+
+/**
+ * API for a factory service that creates {@link InvoiceFormatter} instances.
+ * 
+ * @author matt
+ */
+public interface InvoiceFormatterFactory {
+
+    /**
+     * Create an {@link InvoiceFormatter} instance for a given {@link Invoice}.
+     * 
+     * @param translator the available translations
+     * @param invoice the invoice
+     * @param locale the desired locale
+     * @return the formatter instance, never {@literal null}
+     */
+    InvoiceFormatter createInvoiceFormatter(
+            Map<String, String> translator,
+            Invoice invoice,
+            Locale locale);
+
+}

--- a/src/main/java/org/killbill/billing/plugin/notification/generator/TemplateRenderer.java
+++ b/src/main/java/org/killbill/billing/plugin/notification/generator/TemplateRenderer.java
@@ -116,11 +116,11 @@ public class TemplateRenderer {
             data.put("subscription", subscription);
         }
         if (invoice != null) {
-        	// look for a custom InvoiceFormatter via our factory service tracker, if available
-        	final InvoiceFormatterFactory formatterFactory = (invoiceFormatterTracker != null ? invoiceFormatterTracker.getService() : null);
+            // look for a custom InvoiceFormatter via our factory service tracker, if available
+            final InvoiceFormatterFactory formatterFactory = (invoiceFormatterTracker != null ? invoiceFormatterTracker.getService() : null);
             InvoiceFormatter formattedInvoice = (formatterFactory != null ? formatterFactory.createInvoiceFormatter(text, invoice, locale) : null);
             if ( formattedInvoice == null ) {
-            	formattedInvoice = new DefaultInvoiceFormatter(text, invoice, locale);
+                formattedInvoice = new DefaultInvoiceFormatter(text, invoice, locale);
             }
             data.put("invoice", formattedInvoice);
         }

--- a/src/main/java/org/killbill/billing/plugin/notification/generator/TemplateRenderer.java
+++ b/src/main/java/org/killbill/billing/plugin/notification/generator/TemplateRenderer.java
@@ -23,6 +23,7 @@ import org.killbill.billing.entitlement.api.Subscription;
 import org.killbill.billing.invoice.api.Invoice;
 import org.killbill.billing.invoice.api.formatters.InvoiceFormatter;
 import org.killbill.billing.payment.api.PaymentTransaction;
+import org.killbill.billing.plugin.notification.api.InvoiceFormatterFactory;
 import org.killbill.billing.plugin.notification.email.EmailContent;
 import org.killbill.billing.plugin.notification.exception.EmailNotificationException;
 import org.killbill.billing.plugin.notification.exception.EmailNotificationException;
@@ -36,6 +37,7 @@ import org.killbill.billing.tenant.api.TenantApiException;
 import org.killbill.billing.tenant.api.TenantUserApi;
 import org.killbill.billing.util.callcontext.TenantContext;
 import org.osgi.service.log.LogService;
+import org.osgi.util.tracker.ServiceTracker;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -60,6 +62,7 @@ public class TemplateRenderer {
     private final ResourceBundleFactory bundleFactory;
     private final TenantUserApi tenantApi;
     private final LogService logService;
+    private ServiceTracker<InvoiceFormatterFactory, InvoiceFormatterFactory> invoiceFormatterTracker;
 
     public TemplateRenderer(final TemplateEngine templateEngine,
                             final ResourceBundleFactory bundleFactory,
@@ -113,7 +116,12 @@ public class TemplateRenderer {
             data.put("subscription", subscription);
         }
         if (invoice != null) {
-            final InvoiceFormatter formattedInvoice = new DefaultInvoiceFormatter(text, invoice, locale);
+        	// look for a custom InvoiceFormatter via our factory service tracker, if available
+        	final InvoiceFormatterFactory formatterFactory = (invoiceFormatterTracker != null ? invoiceFormatterTracker.getService() : null);
+            InvoiceFormatter formattedInvoice = (formatterFactory != null ? formatterFactory.createInvoiceFormatter(text, invoice, locale) : null);
+            if ( formattedInvoice == null ) {
+            	formattedInvoice = new DefaultInvoiceFormatter(text, invoice, locale);
+            }
             data.put("invoice", formattedInvoice);
         }
         if (paymentTransaction != null) {
@@ -189,6 +197,18 @@ public class TemplateRenderer {
         } catch (IOException e) {
             return null;
         }
+    }
+
+    /**
+     * Configure a custom {@link InvoiceFormatterFactory} via some other plugin.
+     * 
+     * <p>If this service is not configured, or the tracker does not return a service via {@link ServiceTracker#getService()},
+     * then a {@link DefaultInvoiceFormatter} instance will be used.</p>
+     * 
+     * @param invoiceFormatterTracker the service tracker to use
+     */
+    public void setInvoiceFormatterTracker(ServiceTracker<InvoiceFormatterFactory, InvoiceFormatterFactory> invoiceFormatterTracker) {
+        this.invoiceFormatterTracker = invoiceFormatterTracker;
     }
 
 }

--- a/src/main/java/org/killbill/billing/plugin/notification/generator/TemplateRenderer.java
+++ b/src/main/java/org/killbill/billing/plugin/notification/generator/TemplateRenderer.java
@@ -119,7 +119,7 @@ public class TemplateRenderer {
             // look for a custom InvoiceFormatter via our factory service tracker, if available
             final InvoiceFormatterFactory formatterFactory = (invoiceFormatterTracker != null ? invoiceFormatterTracker.getService() : null);
             InvoiceFormatter formattedInvoice = (formatterFactory != null 
-            		? formatterFactory.createInvoiceFormatter(text, invoice, locale, context) : null);
+                    ? formatterFactory.createInvoiceFormatter(text, invoice, locale, context) : null);
             if ( formattedInvoice == null ) {
                 formattedInvoice = new DefaultInvoiceFormatter(text, invoice, locale);
             }

--- a/src/main/java/org/killbill/billing/plugin/notification/generator/TemplateRenderer.java
+++ b/src/main/java/org/killbill/billing/plugin/notification/generator/TemplateRenderer.java
@@ -118,7 +118,8 @@ public class TemplateRenderer {
         if (invoice != null) {
             // look for a custom InvoiceFormatter via our factory service tracker, if available
             final InvoiceFormatterFactory formatterFactory = (invoiceFormatterTracker != null ? invoiceFormatterTracker.getService() : null);
-            InvoiceFormatter formattedInvoice = (formatterFactory != null ? formatterFactory.createInvoiceFormatter(text, invoice, locale) : null);
+            InvoiceFormatter formattedInvoice = (formatterFactory != null 
+            		? formatterFactory.createInvoiceFormatter(text, invoice, locale, context) : null);
             if ( formattedInvoice == null ) {
                 formattedInvoice = new DefaultInvoiceFormatter(text, invoice, locale);
             }

--- a/src/main/java/org/killbill/billing/plugin/notification/generator/formatters/DefaultInvoiceFormatter.java
+++ b/src/main/java/org/killbill/billing/plugin/notification/generator/formatters/DefaultInvoiceFormatter.java
@@ -273,4 +273,23 @@ public class DefaultInvoiceFormatter implements InvoiceFormatter {
     public String getFormattedRefundedAmount() {
         return getFormattedAmountByLocaleAndInvoiceCurrency(getRefundedAmount(), getCurrency().toString(), locale);
     }
+
+    // Expose the fields for children classes. This is useful for further customization of the invoices
+
+    protected Map<String, String> getTranslator() {
+		return translator;
+	}
+
+	protected Invoice getInvoice() {
+		return invoice;
+	}
+
+	protected Locale getLocale() {
+		return locale;
+	}
+
+	protected DateTimeFormatter getDateFormatter() {
+		return dateFormatter;
+	}
+    
 }

--- a/src/main/java/org/killbill/billing/plugin/notification/generator/formatters/DefaultInvoiceFormatter.java
+++ b/src/main/java/org/killbill/billing/plugin/notification/generator/formatters/DefaultInvoiceFormatter.java
@@ -277,19 +277,19 @@ public class DefaultInvoiceFormatter implements InvoiceFormatter {
     // Expose the fields for children classes. This is useful for further customization of the invoices
 
     protected Map<String, String> getTranslator() {
-		return translator;
-	}
+        return translator;
+    }
 
-	protected Invoice getInvoice() {
-		return invoice;
-	}
+    protected Invoice getInvoice() {
+        return invoice;
+    }
 
-	protected Locale getLocale() {
-		return locale;
-	}
+    protected Locale getLocale() {
+        return locale;
+    }
 
-	protected DateTimeFormatter getDateFormatter() {
-		return dateFormatter;
-	}
+    protected DateTimeFormatter getDateFormatter() {
+        return dateFormatter;
+    }
     
 }

--- a/src/main/java/org/killbill/billing/plugin/notification/setup/EmailNotificationActivator.java
+++ b/src/main/java/org/killbill/billing/plugin/notification/setup/EmailNotificationActivator.java
@@ -82,7 +82,7 @@ public class EmailNotificationActivator extends KillbillActivatorBase {
         super.stop(context);
 
         if (invoiceFormatterTracker != null) {
-        	invoiceFormatterTracker.close();
+            invoiceFormatterTracker.close();
         }
     }
 

--- a/src/main/java/org/killbill/billing/plugin/notification/setup/EmailNotificationActivator.java
+++ b/src/main/java/org/killbill/billing/plugin/notification/setup/EmailNotificationActivator.java
@@ -50,7 +50,7 @@ public class EmailNotificationActivator extends KillbillActivatorBase {
         super.start(context);
 
         final String region = PluginEnvironmentConfig.getRegion(configProperties.getProperties());
-        
+
         // Register an event listener for plugin configuration (optional)
         emailNotificationConfigurationHandler = new EmailNotificationConfigurationHandler(region, PLUGIN_NAME, killbillAPI, logService, dataSource);
         final EmailNotificationConfiguration globalConfiguration = emailNotificationConfigurationHandler.createConfigurable(configProperties.getProperties());

--- a/src/main/java/org/killbill/billing/plugin/notification/setup/EmailNotificationListener.java
+++ b/src/main/java/org/killbill/billing/plugin/notification/setup/EmailNotificationListener.java
@@ -40,6 +40,7 @@ import org.killbill.billing.invoice.api.DryRunType;
 import org.killbill.billing.invoice.api.Invoice;
 import org.killbill.billing.invoice.api.InvoiceApiException;
 import org.killbill.billing.invoice.api.InvoicePayment;
+import org.killbill.billing.invoice.api.formatters.InvoiceFormatter;
 import org.killbill.billing.notification.plugin.api.ExtBusEvent;
 import org.killbill.billing.notification.plugin.api.ExtBusEventType;
 import org.killbill.billing.notification.plugin.api.NotificationPluginApiRetryException;
@@ -62,10 +63,12 @@ import org.killbill.billing.plugin.notification.generator.ResourceBundleFactory;
 import org.killbill.billing.plugin.notification.generator.TemplateRenderer;
 import org.killbill.billing.plugin.notification.templates.MustacheTemplateEngine;
 import org.killbill.billing.plugin.notification.dao.gen.tables.pojos.EmailNotificationsConfiguration;
+import org.killbill.billing.plugin.notification.api.InvoiceFormatterFactory;
 import org.killbill.billing.plugin.notification.dao.ConfigurationDao;
 import org.killbill.billing.tenant.api.TenantApiException;
 import org.killbill.billing.util.callcontext.TenantContext;
 import org.osgi.service.log.LogService;
+import org.osgi.util.tracker.ServiceTracker;
 import org.skife.config.TimeSpan;
 
 import javax.annotation.Nullable;
@@ -98,13 +101,15 @@ public class EmailNotificationListener implements OSGIKillbillEventDispatcher.OS
 
 
     public EmailNotificationListener(final OSGIKillbillClock clock, final OSGIKillbillLogService logService, final OSGIKillbillAPI killbillAPI, final OSGIConfigPropertiesService configProperties,
-                                     OSGIKillbillDataSource dataSource, EmailNotificationConfigurationHandler emailNotificationConfigurationHandler) throws SQLException {
+                                     OSGIKillbillDataSource dataSource, EmailNotificationConfigurationHandler emailNotificationConfigurationHandler,
+                                     final ServiceTracker<InvoiceFormatterFactory, InvoiceFormatterFactory> invoiceFormatterTracker) throws SQLException {
         this.logService = logService;
         this.osgiKillbillAPI = killbillAPI;
         this.configProperties = configProperties;
         this.clock = clock;
         this.emailSender = new EmailSender(configProperties, logService);
         this.templateRenderer = new TemplateRenderer(new MustacheTemplateEngine(), new ResourceBundleFactory(killbillAPI.getTenantUserApi(), logService), killbillAPI.getTenantUserApi(), logService);
+        this.templateRenderer.setInvoiceFormatterTracker(invoiceFormatterTracker);
         this.dao = new ConfigurationDao(dataSource.getDataSource());
         this.emailNotificationConfigurationHandler = emailNotificationConfigurationHandler;
     }

--- a/src/test/java/org/killbill/billing/plugin/notification/generator/TestTemplateRenderer.java
+++ b/src/test/java/org/killbill/billing/plugin/notification/generator/TestTemplateRenderer.java
@@ -138,7 +138,7 @@ public class TestTemplateRenderer {
         renderer = new TemplateRenderer(templateEngine, bundleFactory, getMockTenantUserApi(), logService);
     }
     
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     public void beforeMethdo() {
     	MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/org/killbill/billing/plugin/notification/generator/TestTemplateRenderer.java
+++ b/src/test/java/org/killbill/billing/plugin/notification/generator/TestTemplateRenderer.java
@@ -17,6 +17,11 @@
 
 package org.killbill.billing.plugin.notification.generator;
 
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.anyMap;
+import static org.mockito.Mockito.eq;
+
 import com.google.common.collect.ImmutableList;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -30,9 +35,6 @@ import org.killbill.billing.catalog.api.Currency;
 import org.killbill.billing.catalog.api.PhaseType;
 import org.killbill.billing.catalog.api.Plan;
 import org.killbill.billing.catalog.api.PlanPhase;
-import org.killbill.billing.catalog.api.PlanPhasePriceOverride;
-import org.killbill.billing.catalog.api.PlanPhaseSpecifier;
-import org.killbill.billing.catalog.api.PlanSpecifier;
 import org.killbill.billing.catalog.api.PriceList;
 import org.killbill.billing.catalog.api.Product;
 import org.killbill.billing.catalog.api.ProductCategory;
@@ -47,26 +49,36 @@ import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.InvoiceItemType;
 import org.killbill.billing.invoice.api.InvoicePayment;
 import org.killbill.billing.invoice.api.InvoiceStatus;
+import org.killbill.billing.invoice.api.formatters.InvoiceFormatter;
 import org.killbill.billing.payment.api.PaymentTransaction;
 import org.killbill.billing.payment.api.PluginProperty;
 import org.killbill.billing.payment.api.TransactionStatus;
 import org.killbill.billing.payment.api.TransactionType;
 import org.killbill.billing.payment.plugin.api.PaymentTransactionInfoPlugin;
+import org.killbill.billing.plugin.notification.api.InvoiceFormatterFactory;
 import org.killbill.billing.plugin.notification.email.EmailContent;
 import org.killbill.billing.plugin.notification.templates.MustacheTemplateEngine;
 import org.killbill.billing.plugin.notification.templates.TemplateEngine;
+import org.killbill.billing.plugin.notification.util.LocaleUtils;
 import org.killbill.billing.tenant.api.Tenant;
 import org.killbill.billing.tenant.api.TenantApiException;
 import org.killbill.billing.tenant.api.TenantData;
 import org.killbill.billing.tenant.api.TenantUserApi;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.callcontext.TenantContext;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.log.LogService;
+import org.osgi.util.tracker.ServiceTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
@@ -75,6 +87,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
@@ -82,9 +95,25 @@ public class TestTemplateRenderer {
 
     private final Logger log = LoggerFactory.getLogger(TestTemplateRenderer.class);
 
+    @Mock
+	private BundleContext bundleContext;
+    
+    @Mock
+    private Bundle bundle;
+    
+    @Mock
+    private ServiceReference<InvoiceFormatterFactory> invoiceFormatterFactoryRef;
+    
+    @Mock
+    private InvoiceFormatterFactory invoiceFormatterFactory;
+    
+    @Mock
+    private InvoiceFormatter invoiceFormatter;
+    
     private TemplateRenderer renderer;
 
     @BeforeClass(groups = "fast")
+    @SuppressWarnings("rawtypes")
     public void beforeClass() throws Exception {
 
         LogService logService = new LogService() {
@@ -96,7 +125,7 @@ public class TestTemplateRenderer {
             public void log(int i, String s, Throwable throwable) {
                 log.info(s, throwable);
             }
-            @Override
+			@Override
             public void log(ServiceReference serviceReference, int i, String s) {
             }
             @Override
@@ -107,6 +136,11 @@ public class TestTemplateRenderer {
         final TemplateEngine templateEngine = new MustacheTemplateEngine();
         final ResourceBundleFactory bundleFactory = new ResourceBundleFactory(getMockTenantUserApi(), logService);
         renderer = new TemplateRenderer(templateEngine, bundleFactory, getMockTenantUserApi(), logService);
+    }
+    
+    @BeforeMethod
+    public void beforeMethdo() {
+    	MockitoAnnotations.initMocks(this);
     }
 
     @Test(groups = "fast")
@@ -337,6 +371,57 @@ public class TestTemplateRenderer {
         //System.err.println(email.getBody());
         Assert.assertEquals(email.getSubject(), "You Have a New Invoice");
 
+        Assert.assertEquals(email.getBody(), expectedBody);
+    }
+    
+    @Test(groups = "fast")
+    public void testCreateInvoiceWithCustomFormatterFactory() throws Exception {
+    	// GIVEN
+    	given(invoiceFormatterFactoryRef.getProperty(Constants.SERVICE_ID)).willReturn("foo.bar");
+    	given(invoiceFormatterFactoryRef.getBundle()).willReturn(bundle);
+    	given(bundleContext.getService(invoiceFormatterFactoryRef)).willReturn(invoiceFormatterFactory);
+    	
+    	final ServiceTracker<InvoiceFormatterFactory, InvoiceFormatterFactory> tracker = new ServiceTracker<>(
+    			bundleContext, invoiceFormatterFactoryRef, null);
+    	renderer.setInvoiceFormatterTracker(tracker);
+    	
+        final AccountData account = createAccount();
+        final Locale accountLocale = LocaleUtils.toLocale(account.getLocale());
+        final List<InvoiceItem> items = new ArrayList<InvoiceItem>();
+        items.add(createInvoiceItem(InvoiceItemType.RECURRING, new LocalDate("2015-04-06"), new BigDecimal("123.45"), account.getCurrency(), "chocolate-monthly"));
+        items.add(createInvoiceItem(InvoiceItemType.TAX, new LocalDate("2015-04-06"), new BigDecimal("7.5500"), account.getCurrency(), "chocolate-monthly"));
+        final Invoice invoice = createInvoice(234, new LocalDate("2015-04-06"), new BigDecimal("131.00"), BigDecimal.ZERO, account.getCurrency(), items);
+        final TenantContext tenantContext = createTenantContext();
+        
+        @SuppressWarnings("unchecked")
+		Map<String, String> anyMap = anyMap();
+        given(invoiceFormatterFactory.createInvoiceFormatter(anyMap, eq(invoice), 
+        		eq(accountLocale), eq(tenantContext))).willReturn(invoiceFormatter);
+        
+        given(invoiceFormatter.getTargetDate()).willReturn(new LocalDate(2020,7,16));
+        given(invoiceFormatter.getFormattedBalance()).willReturn("FOO$ 9.99");
+
+        // WHEN
+        tracker.open();
+        final EmailContent email = renderer.generateEmailForInvoiceCreation(account, invoice, tenantContext);
+    	
+        // THEN
+        final String expectedBody = "*** You Have a New Invoice ***\n" +
+                "\n" +
+                "You have a new invoice from MERCHANT_NAME, due on 2020-07-16.\n" +
+                "\n" +
+                "\n" +
+                "Total: FOO$ 9.99\n" +
+                "\n" +
+                "Billed To::\n" +
+                "SauvonsLaTerre\n" +
+                "Sylvie Dupond\n" +
+                "1234 Trumpet street\n" +
+                "San Francisco, CA 94110\n" +
+                "USA\n" +
+                "\n" +
+                "If you have any questions about your account, please reply to this email or contact MERCHANT_NAME Support at: (888) 555-1234";
+        Assert.assertEquals(email.getSubject(), "You Have a New Invoice");
         Assert.assertEquals(email.getBody(), expectedBody);
     }
 

--- a/src/test/java/org/killbill/billing/plugin/notification/generator/TestTemplateRenderer.java
+++ b/src/test/java/org/killbill/billing/plugin/notification/generator/TestTemplateRenderer.java
@@ -138,7 +138,7 @@ public class TestTemplateRenderer {
         renderer = new TemplateRenderer(templateEngine, bundleFactory, getMockTenantUserApi(), logService);
     }
     
-    @BeforeMethod(alwaysRun = true)
+    @BeforeMethod(groups = "fast")
     public void beforeMethdo() {
         MockitoAnnotations.initMocks(this);
     }

--- a/src/test/java/org/killbill/billing/plugin/notification/generator/TestTemplateRenderer.java
+++ b/src/test/java/org/killbill/billing/plugin/notification/generator/TestTemplateRenderer.java
@@ -96,7 +96,7 @@ public class TestTemplateRenderer {
     private final Logger log = LoggerFactory.getLogger(TestTemplateRenderer.class);
 
     @Mock
-	private BundleContext bundleContext;
+    private BundleContext bundleContext;
     
     @Mock
     private Bundle bundle;
@@ -125,7 +125,7 @@ public class TestTemplateRenderer {
             public void log(int i, String s, Throwable throwable) {
                 log.info(s, throwable);
             }
-			@Override
+            @Override
             public void log(ServiceReference serviceReference, int i, String s) {
             }
             @Override
@@ -140,7 +140,7 @@ public class TestTemplateRenderer {
     
     @BeforeMethod(alwaysRun = true)
     public void beforeMethdo() {
-    	MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.initMocks(this);
     }
 
     @Test(groups = "fast")
@@ -376,15 +376,15 @@ public class TestTemplateRenderer {
     
     @Test(groups = "fast")
     public void testCreateInvoiceWithCustomFormatterFactory() throws Exception {
-    	// GIVEN
-    	given(invoiceFormatterFactoryRef.getProperty(Constants.SERVICE_ID)).willReturn("foo.bar");
-    	given(invoiceFormatterFactoryRef.getBundle()).willReturn(bundle);
-    	given(bundleContext.getService(invoiceFormatterFactoryRef)).willReturn(invoiceFormatterFactory);
-    	
-    	final ServiceTracker<InvoiceFormatterFactory, InvoiceFormatterFactory> tracker = new ServiceTracker<>(
-    			bundleContext, invoiceFormatterFactoryRef, null);
-    	renderer.setInvoiceFormatterTracker(tracker);
-    	
+        // GIVEN
+        given(invoiceFormatterFactoryRef.getProperty(Constants.SERVICE_ID)).willReturn("foo.bar");
+        given(invoiceFormatterFactoryRef.getBundle()).willReturn(bundle);
+        given(bundleContext.getService(invoiceFormatterFactoryRef)).willReturn(invoiceFormatterFactory);
+        
+        final ServiceTracker<InvoiceFormatterFactory, InvoiceFormatterFactory> tracker = new ServiceTracker<>(
+                bundleContext, invoiceFormatterFactoryRef, null);
+        renderer.setInvoiceFormatterTracker(tracker);
+        
         final AccountData account = createAccount();
         final Locale accountLocale = LocaleUtils.toLocale(account.getLocale());
         final List<InvoiceItem> items = new ArrayList<InvoiceItem>();
@@ -394,9 +394,9 @@ public class TestTemplateRenderer {
         final TenantContext tenantContext = createTenantContext();
         
         @SuppressWarnings("unchecked")
-		Map<String, String> anyMap = anyMap();
+        Map<String, String> anyMap = anyMap();
         given(invoiceFormatterFactory.createInvoiceFormatter(anyMap, eq(invoice), 
-        		eq(accountLocale), eq(tenantContext))).willReturn(invoiceFormatter);
+                eq(accountLocale), eq(tenantContext))).willReturn(invoiceFormatter);
         
         given(invoiceFormatter.getTargetDate()).willReturn(new LocalDate(2020,7,16));
         given(invoiceFormatter.getFormattedBalance()).willReturn("FOO$ 9.99");
@@ -404,7 +404,7 @@ public class TestTemplateRenderer {
         // WHEN
         tracker.open();
         final EmailContent email = renderer.generateEmailForInvoiceCreation(account, invoice, tenantContext);
-    	
+        
         // THEN
         final String expectedBody = "*** You Have a New Invoice ***\n" +
                 "\n" +

--- a/src/test/java/org/killbill/billing/plugin/notification/generator/TestTemplateRenderer.java
+++ b/src/test/java/org/killbill/billing/plugin/notification/generator/TestTemplateRenderer.java
@@ -217,7 +217,7 @@ public class TestTemplateRenderer {
                 "If you have any questions about your account, please reply to this email or contact MERCHANT_NAME Support at: (888) 555-1234";
 
         //System.err.println(email.getBody());
-        Assert.assertEquals(email.getSubject(), "Payment Confirmation");
+        Assert.assertEquals(email.getSubject(), "Payment Confirmation, Old Boy");
         Assert.assertEquals(email.getBody(), expectedBody);
     }
 

--- a/src/test/resources/org/killbill/billing/plugin/notification/translations/Translation_en_GB.properties
+++ b/src/test/resources/org/killbill/billing/plugin/notification/translations/Translation_en_GB.properties
@@ -1,0 +1,20 @@
+merchantName=MERCHANT_NAME
+merchantContactEmail=MERCHANT_EMAIL
+merchantContactPhone=(888) 555-1234
+
+paymentLink=http://paymentLink
+subscriptionLink=http://subscriptionLink
+
+upcomingInvoiceSubject=You Have a New Invoice
+successfulPaymentSubject=Payment Confirmation, Old Boy
+failedPaymentSubject=Failed Payment
+subscriptionCancellationRequestedSubject=Subscription Canceled
+subscriptionCancellationEffectiveSubject=Subscription Ended
+paymentRefundSubject=Refund Receipt
+invoiceCreationSubject=You Have a New Invoice
+
+invoiceNumber=Invoice #
+paymentDate=Payment Date
+invoiceAmountPaid=Paid
+invoiceAmountTotal=Total
+billedTo=Billed To:


### PR DESCRIPTION
This PR provides a way for a custom [`InvoiceFormatter`](https://github.com/killbill/killbill-api/blob/master/src/main/java/org/killbill/billing/invoice/api/formatters/InvoiceFormatter.java) implementation to be used at runtime. It does this by introducing a new [`InvoiceFormatterFactory`](https://github.com/SolarNetwork/killbill-email-notifications-plugin/blob/feature/extensibility/src/main/java/org/killbill/billing/plugin/notification/api/InvoiceFormatterFactory.java) API and then looking up an OSGi service for that at runtime. If a service is available, the factory will be used to create the `InvoiceFormatter` instance. Otherwise the existing [`DefaultInvoiceFormatter`](https://github.com/SolarNetwork/killbill-email-notifications-plugin/blob/feature/extensibility/src/main/java/org/killbill/billing/plugin/notification/generator/formatters/DefaultInvoiceFormatter.java) class is used.

To allow other plugins to use the `InvoiceFormatterFactory` class at runtime, and then extend the existing support classes, this plugin now exports these packages in OSGi:

```
org.killbill.billing.plugin.notification.api
org.killbill.billing.plugin.notification.generator
org.killbill.billing.plugin.notification.generator.formatters
```

To see an intended use case, I've extended an [existing custom `InvoiceFormatter` project](https://github.com/SolarNetwork/killbill-invoice-formatter) that is used to customize the HTML invoice generation done internally in Killbill so that it can work with the email-notifications-plugin as well. Its `BundleActivator` [registers a `SolarNetworkInvoiceFormatterFactory` service](https://github.com/SolarNetwork/killbill-invoice-formatter/blob/e02b6b2f9301fb7ab08acc3080f2a1d2919b643e/src/main/java/net/solarnetwork/billing/killbill/invoice/notification/Activator.java#L39-L42).

Finally, I've added a new [test case](https://github.com/SolarNetwork/killbill-email-notifications-plugin/blob/7fa1a73c52b9d2563b789b50a8bc748cabe5e5ca/src/test/java/org/killbill/billing/plugin/notification/generator/TestTemplateRenderer.java#L378-L426) that verifies the factory is used as expected.