### PR TITLE
Change Mustache compiler to default null values to empty strings

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/notification/templates/MustacheTemplateEngine.java
+++ b/src/main/java/org/killbill/billing/plugin/notification/templates/MustacheTemplateEngine.java
@@ -26,7 +26,7 @@ public class MustacheTemplateEngine implements TemplateEngine {
 
     @Override
     public String executeTemplateText(final String templateText, final Map<String, Object> data) {
-        final Template template = Mustache.compiler().compile(templateText);
+        final Template template = Mustache.compiler().nullValue("").compile(templateText);
         return template.execute(data);
     }
 }


### PR DESCRIPTION
Currently the Mustache compiler will throw an exception if any template parameter resolves to `null`. This is different from how the Mustache compiler used internally by Killbill [is configured](https://github.com/killbill/killbill/blob/a61afae430e103feba18b65772ec225fe2266105/util/src/main/java/org/killbill/billing/util/email/templates/MustacheTemplateEngine.java#L28), which resolves `null` values to empty strings. This PR updates this plugin to follow the same behavior used by the internal configuration.