### PR TITLE
Oss 552 update parent and db testing server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.145.3-6e4b9ef-SNAPSHOT</version>
+        <version>0.145.3-8ff3c94-SNAPSHOT</version>
     </parent>
     <groupId>org.kill-bill.billing.plugin.java</groupId>
     <artifactId>killbill-email-notifications-plugin</artifactId>
@@ -74,13 +74,8 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>testing-mysql-server</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>testing-postgresql-server</artifactId>
+            <groupId>io.zonky.test</groupId>
+            <artifactId>embedded-postgres</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -211,6 +206,11 @@
             <groupId>org.kill-bill.commons</groupId>
             <artifactId>killbill-metrics-api</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kill-bill.testing</groupId>
+            <artifactId>testing-mysql-server</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/src/main/java/org/killbill/billing/plugin/notification/setup/EmailNotificationListener.java
+++ b/src/main/java/org/killbill/billing/plugin/notification/setup/EmailNotificationListener.java
@@ -21,6 +21,7 @@ package org.killbill.billing.plugin.notification.setup;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.UUID;
 
 import org.apache.commons.mail.EmailException;
@@ -229,7 +230,12 @@ public class EmailNotificationListener implements OSGIKillbillEventDispatcher.OS
         try {
         	final EmailNotificationConfiguration emailNotificationConfiguration = getConfiguration(context);
         	osgiKillbillAPI.getSecurityApi().login(emailNotificationConfiguration.getAdminUsername(), emailNotificationConfiguration.getAdminPassword());
-        	final Invoice invoice = osgiKillbillAPI.getInvoiceUserApi().triggerDryRunInvoiceGeneration(account.getId(), new LocalDate(targetDateTime, account.getTimeZone()), NULL_DRY_RUN_ARGUMENTS, callContext);
+        	final Invoice invoice = osgiKillbillAPI.getInvoiceUserApi().triggerDryRunInvoiceGeneration(
+                    account.getId(),
+                    new LocalDate(targetDateTime, account.getTimeZone()),
+                    NULL_DRY_RUN_ARGUMENTS,
+                    Collections.emptyList(),
+                    callContext);
         	if (invoice != null) {
         		final EmailContent emailContent = templateRenderer.generateEmailForUpComingInvoice(account, invoice, context);
         		sendEmail(account, emailContent, context);
@@ -244,7 +250,7 @@ public class EmailNotificationListener implements OSGIKillbillEventDispatcher.OS
         Preconditions.checkArgument(killbillEvent.getEventType() == ExtBusEventType.SUBSCRIPTION_CANCEL, String.format("Unexpected event %s", killbillEvent.getEventType()));
         final UUID subscriptionId = killbillEvent.getObjectId();
 
-        final Subscription subscription = osgiKillbillAPI.getSubscriptionApi().getSubscriptionForEntitlementId(subscriptionId, context);
+        final Subscription subscription = osgiKillbillAPI.getSubscriptionApi().getSubscriptionForEntitlementId(subscriptionId, false, context);
         if (subscription != null) {
             final EmailContent emailContent = subscription.getState() == Entitlement.EntitlementState.CANCELLED ?
                     templateRenderer.generateEmailForSubscriptionCancellationEffective(account, subscription, context) :


### PR DESCRIPTION
Notes: Seems like `killbill-api` used by this library pretty obsolete. When I update oss-parent to the latest, I need to adjust and add additional parameter to following methods:

- Add `Collections.emptyList()` to `InvoiceUserApi.triggerDryRunInvoiceGeneration()` parameter
- Add `false` to `SubscriptionApi.getSubscriptionForEntitlementId()` parameter