### PR TITLE
Email notification plugin issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Kill Bill compatibility
 |          0.5.y |            0.20.z |
 |          0.6.y |            0.22.z |
 |          0.7.y |            0.22.z |
-|          0.8.y |            0.23.z |
+|          0.8.y |            0.24.z |
 
 We've upgraded numerous dependencies in 0.7.x (required for Java 11 support).
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.145.3-8ff3c94-SNAPSHOT</version>
+        <version>0.146.6</version>
     </parent>
     <groupId>org.kill-bill.billing.plugin.java</groupId>
     <artifactId>killbill-email-notifications-plugin</artifactId>
@@ -60,6 +60,12 @@
         <dependency>
             <groupId>com.samskivert</groupId>
             <artifactId>jmustache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>jakarta.activation</artifactId>
+            <version>2.0.0</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.mail</groupId>


### PR DESCRIPTION
This PR is to demonstrate the issue with the email notification plugin. In this PR, the ` jakarta.activation` dependency is added to the `pom.xml`. However, the build fails with the following error:
```
[INFO] --- maven-enforcer-plugin:3.1.0:enforce (default) @ killbill-email-notifications-plugin ---
[ERROR] Rule 0: org.apache.maven.plugins.enforcer.BannedDependencies failed with message:
Found Banned Dependency: com.sun.activation:jakarta.activation:jar:2.0.0
Use 'mvn dependency:tree' to locate the source of the banned dependencies.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
```

This is because this dependency is specified as a banned dependency in the [oss-parent/pom.xml](https://github.com/killbill/killbill-oss-parent/blob/713edf0dec8aafc388acf4df1d7864cfdc8523c4/pom.xml#L1881).

Could you please elaborate a bit on this [comment](https://github.com/killbill/killbill-oss-parent/pull/658#pullrequestreview-1217544103) as to how we can override the plugin config?