### PR TITLE
Unnecessary configuration logging

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/notification/setup/EmailNotificationConfigurationHandler.java
+++ b/src/main/java/org/killbill/billing/plugin/notification/setup/EmailNotificationConfigurationHandler.java
@@ -60,7 +60,6 @@ public class EmailNotificationConfigurationHandler extends PluginTenantConfigura
 
     @Override
     protected EmailNotificationConfiguration createConfigurable(final Properties properties) {
-        logger.info("New properties for region {}: {}", region, properties);
         try {
             return new EmailNotificationConfiguration(properties);
         } catch (final Exception e) {


### PR DESCRIPTION
I noticed the email plugin is logging all properties passed to the plugin, including credentials in properties file in unmasked view. In the current state it logs not only credentials to the SMTP server, but also properties for other plugins, e.g. stripe api key. 

While there are some options to [filter sensitive logs](https://docs.killbill.io/latest/userguide_configuration#_logging_properties), they didn't pick up property values. As this logs are not critical, its safer to remove them altogether.